### PR TITLE
Pull bot config

### DIFF
--- a/.github/pull.yml
+++ b/.github/pull.yml
@@ -1,0 +1,7 @@
+version: "1"
+rules:                      # Array of rules
+  - base: master            # Required. Target branch
+    upstream: Skyrat-SS13/Skyrat-tg    # Required. Must be in the same fork network.
+    mergeMethod: merge # Optional, one of [none, merge, squash, rebase, hardreset], Default: none.
+    mergeUnstable: false    # Optional, merge pull request even when the mergeable_state is not clean. Default: false
+label: "Automatic-Update"  # Optional


### PR DESCRIPTION
Adds config for Pull bot; Bot which will automtically update the repo
and, hopefully, bypass Github's shitlisting of Skyrat.
https://github.com/apps/pull


Config changes:
Repository to sync: https://github.com/Skyrat-SS13/Skyrat-tg
Method of tsync: Merge (Default was HardReset)